### PR TITLE
Checkpoint & Resume: profilleme sirasinda ara kayit (#26)

### DIFF
--- a/sql/mssql/metadata.sql
+++ b/sql/mssql/metadata.sql
@@ -22,7 +22,8 @@ SELECT
     rs.name AS referenced_schema,
     rt.name AS referenced_table,
     rc.name AS referenced_column,
-    ep.value AS column_description
+    ep.value AS column_description,
+    tep.value AS table_description
 FROM sys.columns c
 INNER JOIN sys.tables t ON c.object_id = t.object_id
 INNER JOIN sys.schemas s ON t.schema_id = s.schema_id
@@ -49,5 +50,10 @@ LEFT JOIN sys.extended_properties ep
     AND ep.minor_id = c.column_id
     AND ep.name = 'MS_Description'
     AND ep.class = 1
+LEFT JOIN sys.extended_properties tep
+    ON tep.major_id = t.object_id
+    AND tep.minor_id = 0
+    AND tep.name = 'MS_Description'
+    AND tep.class = 1
 WHERE s.name = ?
 ORDER BY t.name, c.column_id;

--- a/sql/mssql/metadata.sql
+++ b/sql/mssql/metadata.sql
@@ -21,7 +21,8 @@ SELECT
     fk_obj.name AS fk_constraint,
     rs.name AS referenced_schema,
     rt.name AS referenced_table,
-    rc.name AS referenced_column
+    rc.name AS referenced_column,
+    ep.value AS column_description
 FROM sys.columns c
 INNER JOIN sys.tables t ON c.object_id = t.object_id
 INNER JOIN sys.schemas s ON t.schema_id = s.schema_id
@@ -43,5 +44,10 @@ LEFT JOIN sys.schemas rs ON rt.schema_id = rs.schema_id
 LEFT JOIN sys.columns rc
     ON fkc.referenced_object_id = rc.object_id
     AND fkc.referenced_column_id = rc.column_id
+LEFT JOIN sys.extended_properties ep
+    ON ep.major_id = c.object_id
+    AND ep.minor_id = c.column_id
+    AND ep.name = 'MS_Description'
+    AND ep.class = 1
 WHERE s.name = ?
 ORDER BY t.name, c.column_id;

--- a/sql/oracle/metadata.sql
+++ b/sql/oracle/metadata.sql
@@ -11,8 +11,13 @@ SELECT
     fk.constraint_name                                AS fk_constraint,
     fk.r_owner                                        AS referenced_schema,
     fk.r_table_name                                   AS referenced_table,
-    fk.r_column_name                                  AS referenced_column
+    fk.r_column_name                                  AS referenced_column,
+    cc.comments                                       AS column_description
 FROM all_tab_columns c
+LEFT JOIN all_col_comments cc
+    ON cc.owner = c.owner
+    AND cc.table_name = c.table_name
+    AND cc.column_name = c.column_name
 LEFT JOIN (
     SELECT acc.owner, acc.table_name, acc.column_name, acc.constraint_name
     FROM all_cons_columns acc

--- a/sql/oracle/metadata.sql
+++ b/sql/oracle/metadata.sql
@@ -12,12 +12,16 @@ SELECT
     fk.r_owner                                        AS referenced_schema,
     fk.r_table_name                                   AS referenced_table,
     fk.r_column_name                                  AS referenced_column,
-    cc.comments                                       AS column_description
+    cc.comments                                       AS column_description,
+    tc.comments                                       AS table_description
 FROM all_tab_columns c
 LEFT JOIN all_col_comments cc
     ON cc.owner = c.owner
     AND cc.table_name = c.table_name
     AND cc.column_name = c.column_name
+LEFT JOIN all_tab_comments tc
+    ON tc.owner = c.owner
+    AND tc.table_name = c.table_name
 LEFT JOIN (
     SELECT acc.owner, acc.table_name, acc.column_name, acc.constraint_name
     FROM all_cons_columns acc

--- a/sql/postgresql/metadata.sql
+++ b/sql/postgresql/metadata.sql
@@ -18,7 +18,8 @@ SELECT
     fk.referenced_schema,
     fk.referenced_table,
     fk.referenced_column,
-    pgd.description AS column_description
+    pgd.description AS column_description,
+    tgd.description AS table_description
 FROM information_schema.columns c
 LEFT JOIN pg_catalog.pg_statio_all_columns psa
     ON psa.schemaname = c.table_schema
@@ -27,6 +28,12 @@ LEFT JOIN pg_catalog.pg_statio_all_columns psa
 LEFT JOIN pg_catalog.pg_description pgd
     ON pgd.objoid = psa.relid
     AND pgd.objsubid = c.ordinal_position
+LEFT JOIN pg_catalog.pg_class tbl
+    ON tbl.relname = c.table_name
+    AND tbl.relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = c.table_schema)
+LEFT JOIN pg_catalog.pg_description tgd
+    ON tgd.objoid = tbl.oid
+    AND tgd.objsubid = 0
 LEFT JOIN (
     SELECT
         n.nspname   AS table_schema,

--- a/sql/postgresql/metadata.sql
+++ b/sql/postgresql/metadata.sql
@@ -18,22 +18,21 @@ SELECT
     fk.referenced_schema,
     fk.referenced_table,
     fk.referenced_column,
-    pgd.description AS column_description,
-    tgd.description AS table_description
+    col_desc.description AS column_description,
+    tbl_desc.description AS table_description
 FROM information_schema.columns c
-LEFT JOIN pg_catalog.pg_statio_all_columns psa
-    ON psa.schemaname = c.table_schema
-    AND psa.tablename = c.table_name
-    AND psa.attname = c.column_name
-LEFT JOIN pg_catalog.pg_description pgd
-    ON pgd.objoid = psa.relid
-    AND pgd.objsubid = c.ordinal_position
 LEFT JOIN pg_catalog.pg_class tbl
     ON tbl.relname = c.table_name
-    AND tbl.relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = c.table_schema)
-LEFT JOIN pg_catalog.pg_description tgd
-    ON tgd.objoid = tbl.oid
-    AND tgd.objsubid = 0
+    AND tbl.relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = c.table_schema LIMIT 1)
+LEFT JOIN pg_catalog.pg_attribute att
+    ON att.attrelid = tbl.oid
+    AND att.attname = c.column_name
+LEFT JOIN pg_catalog.pg_description col_desc
+    ON col_desc.objoid = tbl.oid
+    AND col_desc.objsubid = att.attnum
+LEFT JOIN pg_catalog.pg_description tbl_desc
+    ON tbl_desc.objoid = tbl.oid
+    AND tbl_desc.objsubid = 0
 LEFT JOIN (
     SELECT
         n.nspname   AS table_schema,

--- a/sql/postgresql/metadata.sql
+++ b/sql/postgresql/metadata.sql
@@ -17,8 +17,16 @@ SELECT
     fk.fk_constraint,
     fk.referenced_schema,
     fk.referenced_table,
-    fk.referenced_column
+    fk.referenced_column,
+    pgd.description AS column_description
 FROM information_schema.columns c
+LEFT JOIN pg_catalog.pg_statio_all_columns psa
+    ON psa.schemaname = c.table_schema
+    AND psa.tablename = c.table_name
+    AND psa.attname = c.column_name
+LEFT JOIN pg_catalog.pg_description pgd
+    ON pgd.objoid = psa.relid
+    AND pgd.objsubid = c.ordinal_position
 LEFT JOIN (
     SELECT
         n.nspname   AS table_schema,

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -73,6 +73,7 @@ export function loadConfig(configPath: string): AppConfig {
       },
       stringPatterns: data.profiling.string_patterns,
       sensitivityThreshold: data.profiling.sensitivity_threshold,
+      checkpointInterval: data.profiling.checkpoint_interval,
     },
     mapping: {
       enabled: data.mapping.enabled,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -45,6 +45,7 @@ const profilingConfigSchema = z.object({
     credit_card: '^[0-9]{13,19}$',
   }),
   sensitivity_threshold: z.enum(['none', 'low', 'medium', 'high']).default('low'),
+  checkpoint_interval: z.coerce.number().int().min(10).default(100),
 }).default({});
 
 const mappingConfigSchema = z.object({

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -41,6 +41,7 @@ export interface ProfilingConfig {
   qualityWeights: QualityWeights;
   stringPatterns: Record<string, string>;
   sensitivityThreshold: SensitivityLevel;
+  checkpointInterval: number;
 }
 
 export interface MappingConfig {

--- a/src/connectors/hanabw-connector.ts
+++ b/src/connectors/hanabw-connector.ts
@@ -179,11 +179,19 @@ export class HanaBwConnector extends BaseConnector {
       });
     }
 
-    return rows.map((r) => ({
-      table_name: String(r.table_name),
-      table_type: String(r.table_type),
-      estimated_rows: Number(r.estimated_rows ?? 0),
-    }));
+    // BW tablo aciklamalarini yukle (RSDCUBET + RSDODSOT)
+    const descriptions = await this.loadBwTableDescriptions(schema);
+
+    return rows.map((r) => {
+      const name = String(r.table_name);
+      const bwName = HanaBwConnector.extractBwObjectName(name);
+      return {
+        table_name: name,
+        table_type: String(r.table_type),
+        estimated_rows: Number(r.estimated_rows ?? 0),
+        table_description: bwName ? (descriptions.get(bwName) ?? undefined) : undefined,
+      };
+    });
   }
 
   async getEstimatedRowCount(conn: DbConnection, schema: string, table: string): Promise<RowCountResult> {

--- a/src/profiler/__tests__/checkpoint-integration.test.ts
+++ b/src/profiler/__tests__/checkpoint-integration.test.ts
@@ -1,0 +1,118 @@
+// src/profiler/__tests__/checkpoint-integration.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { CheckpointManager } from '../checkpoint-manager.js';
+import type { DatabaseProfile } from '../types.js';
+
+function makeProfile(alias: string, schemaName: string, tableNames: string[]): DatabaseProfile {
+  return {
+    db_alias: alias,
+    db_name: 'testdb',
+    host: 'localhost',
+    profiled_at: new Date().toISOString(),
+    total_schemas: 1,
+    total_tables: tableNames.length,
+    total_columns: 0,
+    total_rows: 0,
+    total_size_bytes: 0,
+    total_size_display: '0 B',
+    schemas: [{
+      schema_name: schemaName,
+      table_count: tableNames.length,
+      total_rows: 0,
+      total_size_bytes: 0,
+      total_size_display: '0 B',
+      tables: tableNames.map((t) => ({
+        schema_name: schemaName,
+        table_name: t,
+        table_type: 'BASE TABLE',
+        row_count: 100,
+        estimated_rows: 100,
+        row_count_estimated: false,
+        column_count: 2,
+        columns: [],
+        profiled_at: new Date().toISOString(),
+        profile_duration_sec: 0.5,
+        sampled: false,
+        sample_percent: null,
+        table_size_bytes: 1024,
+        table_size_display: '1.0 KB',
+        table_quality_score: 0.8,
+        table_quality_grade: 'B',
+        dwh_mapped: false,
+        dwh_target_tables: [],
+      })),
+      schema_quality_score: 0.8,
+    }],
+    overall_quality_score: 0.8,
+  };
+}
+
+describe('Checkpoint resume flow', () => {
+  let tmpDir: string;
+  let mgr: CheckpointManager;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ckpt-integ-'));
+    mgr = new CheckpointManager(tmpDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('simulates crash and resume: completed tables are preserved', () => {
+    const profile = makeProfile('sap_bw', 'SAPABAP1', ['T1', 'T2', 'T3']);
+    const completed = new Set(['SAPABAP1.T1', 'SAPABAP1.T2', 'SAPABAP1.T3']);
+    mgr.save(profile, completed);
+
+    const ckpt = mgr.load('sap_bw');
+    expect(ckpt).not.toBeNull();
+
+    const resumedCompleted = new Set(ckpt!.completed_tables);
+
+    expect(resumedCompleted.has('SAPABAP1.T1')).toBe(true);
+    expect(resumedCompleted.has('SAPABAP1.T2')).toBe(true);
+    expect(resumedCompleted.has('SAPABAP1.T3')).toBe(true);
+    expect(resumedCompleted.has('SAPABAP1.T4')).toBe(false);
+  });
+
+  it('clear after success removes all checkpoint artifacts', () => {
+    const profile = makeProfile('sap_bw', 'SAPABAP1', ['T1']);
+    mgr.save(profile, new Set(['SAPABAP1.T1']));
+
+    expect(fs.existsSync(path.join(tmpDir, '.tmp'))).toBe(true);
+
+    mgr.clear('sap_bw');
+
+    expect(fs.existsSync(path.join(tmpDir, '.tmp'))).toBe(false);
+  });
+
+  it('changed table selection: new tables profiled, removed tables ignored', () => {
+    const profile = makeProfile('db1', 'public', ['T1', 'T2', 'T3']);
+    const completed = new Set(['public.T1', 'public.T2', 'public.T3']);
+    mgr.save(profile, completed);
+
+    const ckpt = mgr.load('db1')!;
+    const resumedCompleted = new Set(ckpt.completed_tables);
+
+    const selectedTables = ['T2', 'T3', 'T4'];
+
+    const toProfile: string[] = [];
+    const toSkip: string[] = [];
+
+    for (const t of selectedTables) {
+      const key = `public.${t}`;
+      if (resumedCompleted.has(key)) {
+        toSkip.push(t);
+      } else {
+        toProfile.push(t);
+      }
+    }
+
+    expect(toSkip).toEqual(['T2', 'T3']);
+    expect(toProfile).toEqual(['T4']);
+  });
+});

--- a/src/profiler/__tests__/checkpoint-integration.test.ts
+++ b/src/profiler/__tests__/checkpoint-integration.test.ts
@@ -28,6 +28,7 @@ function makeProfile(alias: string, schemaName: string, tableNames: string[]): D
         schema_name: schemaName,
         table_name: t,
         table_type: 'BASE TABLE',
+        description: null,
         row_count: 100,
         estimated_rows: 100,
         row_count_estimated: false,

--- a/src/profiler/__tests__/checkpoint-manager.test.ts
+++ b/src/profiler/__tests__/checkpoint-manager.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { CheckpointManager } from '../checkpoint-manager.js';
+import type { DatabaseProfile } from '../types.js';
+
+function makeProfile(alias: string, tables: string[]): DatabaseProfile {
+  return {
+    db_alias: alias,
+    db_name: 'testdb',
+    host: 'localhost',
+    profiled_at: new Date().toISOString(),
+    total_schemas: 1,
+    total_tables: tables.length,
+    total_columns: 0,
+    total_rows: 0,
+    total_size_bytes: 0,
+    total_size_display: '0 B',
+    schemas: [{
+      schema_name: 'public',
+      table_count: tables.length,
+      total_rows: 0,
+      total_size_bytes: 0,
+      total_size_display: '0 B',
+      tables: tables.map((t) => ({
+        schema_name: 'public',
+        table_name: t,
+        table_type: 'BASE TABLE',
+        row_count: 100,
+        estimated_rows: 100,
+        row_count_estimated: false,
+        column_count: 2,
+        columns: [],
+        profiled_at: new Date().toISOString(),
+        profile_duration_sec: 0.5,
+        sampled: false,
+        sample_percent: null,
+        table_size_bytes: 1024,
+        table_size_display: '1.0 KB',
+        table_quality_score: 0.8,
+        table_quality_grade: 'B',
+        dwh_mapped: false,
+        dwh_target_tables: [],
+      })),
+      schema_quality_score: 0.8,
+    }],
+    overall_quality_score: 0.8,
+  };
+}
+
+describe('CheckpointManager', () => {
+  let tmpDir: string;
+  let mgr: CheckpointManager;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ckpt-test-'));
+    mgr = new CheckpointManager(tmpDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('exists() returns false when no checkpoint', () => {
+    expect(mgr.exists('mydb')).toBe(false);
+  });
+
+  it('save() then load() returns checkpoint data', () => {
+    const profile = makeProfile('mydb', ['t1', 't2']);
+    const completed = new Set(['public.t1', 'public.t2']);
+
+    mgr.save(profile, completed);
+
+    expect(mgr.exists('mydb')).toBe(true);
+
+    const loaded = mgr.load('mydb');
+    expect(loaded).not.toBeNull();
+    expect(loaded!.db_alias).toBe('mydb');
+    expect(loaded!.completed_tables).toEqual(['public.t1', 'public.t2']);
+    expect(loaded!.partial_profile.total_tables).toBe(2);
+  });
+
+  it('clear() removes checkpoint file and empty .tmp dir', () => {
+    const profile = makeProfile('mydb', ['t1']);
+    mgr.save(profile, new Set(['public.t1']));
+
+    expect(mgr.exists('mydb')).toBe(true);
+
+    mgr.clear('mydb');
+
+    expect(mgr.exists('mydb')).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, '.tmp'))).toBe(false);
+  });
+
+  it('load() returns null for corrupt JSON', () => {
+    const tmpPath = path.join(tmpDir, '.tmp');
+    fs.mkdirSync(tmpPath, { recursive: true });
+    fs.writeFileSync(path.join(tmpPath, 'checkpoint_bad.json'), '{corrupt', 'utf-8');
+
+    const loaded = mgr.load('bad');
+    expect(loaded).toBeNull();
+  });
+
+  it('save() updates updated_at on subsequent saves', async () => {
+    const profile = makeProfile('mydb', ['t1']);
+    mgr.save(profile, new Set(['public.t1']));
+    const first = mgr.load('mydb')!;
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    mgr.save(profile, new Set(['public.t1', 'public.t2']));
+    const second = mgr.load('mydb')!;
+
+    expect(second.completed_tables.length).toBe(2);
+    expect(new Date(second.updated_at).getTime()).toBeGreaterThanOrEqual(
+      new Date(first.updated_at).getTime(),
+    );
+  });
+
+  it('getInfo() returns table count and timestamp', () => {
+    const profile = makeProfile('mydb', ['t1', 't2', 't3']);
+    mgr.save(profile, new Set(['public.t1', 'public.t2']));
+
+    const info = mgr.getInfo('mydb');
+    expect(info).not.toBeNull();
+    expect(info!.completedCount).toBe(2);
+    expect(info!.updatedAt).toBeTruthy();
+  });
+});

--- a/src/profiler/__tests__/checkpoint-manager.test.ts
+++ b/src/profiler/__tests__/checkpoint-manager.test.ts
@@ -27,6 +27,7 @@ function makeProfile(alias: string, tables: string[]): DatabaseProfile {
         schema_name: 'public',
         table_name: t,
         table_type: 'BASE TABLE',
+        description: null,
         row_count: 100,
         estimated_rows: 100,
         row_count_estimated: false,

--- a/src/profiler/checkpoint-manager.ts
+++ b/src/profiler/checkpoint-manager.ts
@@ -1,0 +1,95 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { getLogger } from '../utils/logger.js';
+import type { DatabaseProfile, CheckpointData } from './types.js';
+
+export interface CheckpointInfo {
+  completedCount: number;
+  updatedAt: string;
+}
+
+export class CheckpointManager {
+  private tmpDir: string;
+
+  constructor(outputDir: string) {
+    this.tmpDir = path.join(outputDir, '.tmp');
+  }
+
+  private filePath(dbAlias: string): string {
+    return path.join(this.tmpDir, `checkpoint_${dbAlias}.json`);
+  }
+
+  exists(dbAlias: string): boolean {
+    return fs.existsSync(this.filePath(dbAlias));
+  }
+
+  save(profile: DatabaseProfile, completedTables: Set<string>): void {
+    const logger = getLogger();
+    try {
+      fs.mkdirSync(this.tmpDir, { recursive: true });
+
+      const existing = this.load(profile.db_alias);
+
+      const data: CheckpointData = {
+        db_alias: profile.db_alias,
+        started_at: existing?.started_at ?? new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        completed_tables: [...completedTables],
+        partial_profile: profile,
+      };
+
+      fs.writeFileSync(this.filePath(profile.db_alias), JSON.stringify(data, null, 2), 'utf-8');
+      logger.info(`[${profile.db_alias}] Checkpoint kaydedildi: ${completedTables.size} tablo`);
+    } catch (e) {
+      logger.error(`[${profile.db_alias}] Checkpoint yazma hatasi: ${e}`);
+    }
+  }
+
+  load(dbAlias: string): CheckpointData | null {
+    const logger = getLogger();
+    const fp = this.filePath(dbAlias);
+
+    if (!fs.existsSync(fp)) return null;
+
+    try {
+      const raw = fs.readFileSync(fp, 'utf-8');
+      return JSON.parse(raw) as CheckpointData;
+    } catch (e) {
+      logger.warn(`[${dbAlias}] Checkpoint okunamadi, sifirdan baslanacak: ${e}`);
+      return null;
+    }
+  }
+
+  clear(dbAlias: string): void {
+    const logger = getLogger();
+    const fp = this.filePath(dbAlias);
+
+    try {
+      if (fs.existsSync(fp)) {
+        fs.unlinkSync(fp);
+      }
+
+      // Remove .tmp dir if empty
+      if (fs.existsSync(this.tmpDir)) {
+        const remaining = fs.readdirSync(this.tmpDir);
+        if (remaining.length === 0) {
+          fs.rmdirSync(this.tmpDir);
+        }
+      }
+
+      logger.info(`[${dbAlias}] Checkpoint temizlendi.`);
+    } catch (e) {
+      logger.warn(`[${dbAlias}] Checkpoint temizleme hatasi: ${e}`);
+    }
+  }
+
+  getInfo(dbAlias: string): CheckpointInfo | null {
+    const data = this.load(dbAlias);
+    if (!data) return null;
+
+    return {
+      completedCount: data.completed_tables.length,
+      updatedAt: data.updated_at,
+    };
+  }
+}

--- a/src/profiler/profiler.ts
+++ b/src/profiler/profiler.ts
@@ -147,6 +147,18 @@ export class Profiler {
     );
     pbar.start(totalTables, completedTables.size, { postfix: '' });
 
+    // Graceful shutdown: Ctrl+C checkpoint kaydedip ciksin
+    let interrupted = false;
+    const onSigint = () => {
+      interrupted = true;
+      pbar.stop();
+      logger.info(`[${this.dbConfig.alias}] SIGINT alindi, checkpoint kaydediliyor...`);
+      this.checkpointManager.save(dbProfile, completedTables);
+      logger.info(`[${this.dbConfig.alias}] Checkpoint kaydedildi (${completedTables.size}/${totalTables} tablo). Devam etmek icin tekrar calistirin.`);
+      process.exit(0);
+    };
+    process.on('SIGINT', onSigint);
+
     for (const schema of schemas) {
       const tables = schemaTables.get(schema) ?? [];
 
@@ -160,6 +172,7 @@ export class Profiler {
       this.checkpointManager.save(dbProfile, completedTables);
     }
 
+    process.removeListener('SIGINT', onSigint);
     pbar.stop();
 
     // Aggregation

--- a/src/profiler/profiler.ts
+++ b/src/profiler/profiler.ts
@@ -171,8 +171,19 @@ export class Profiler {
       // Remove previously checkpointed version of this schema (resume case)
       dbProfile.schemas = dbProfile.schemas.filter((s) => s.schema_name !== schema);
 
-      const schemaProf = await this.profileSchema(schema, tables, pbar, completedTables, dbProfile, prevTableMap);
+      // Push schema early so in-progress tables are visible in checkpoint
+      const schemaProf: SchemaProfile = {
+        schema_name: schema,
+        table_count: tables.length,
+        total_rows: 0,
+        total_size_bytes: 0,
+        total_size_display: '0 B',
+        tables: [],
+        schema_quality_score: 0,
+      };
       dbProfile.schemas.push(schemaProf);
+
+      await this.profileSchema(schema, tables, pbar, completedTables, schemaProf, dbProfile, prevTableMap);
 
       // Checkpoint: save after each schema
       this.checkpointManager.save(dbProfile, completedTables);
@@ -233,20 +244,12 @@ export class Profiler {
     tables: TableInfo[],
     pbar: SingleBar,
     completedTables: Set<string>,
+    schemaProf: SchemaProfile,
     dbProfile: DatabaseProfile,
     prevTableMap?: Map<string, TableProfile>,
-  ): Promise<SchemaProfile> {
+  ): Promise<void> {
     const logger = getLogger();
     const concurrency = this.profConfig.concurrency;
-    const schemaProf: SchemaProfile = {
-      schema_name: schema,
-      table_count: tables.length,
-      total_rows: 0,
-      total_size_bytes: 0,
-      total_size_display: '0 B',
-      tables: [],
-      schema_quality_score: 0,
-    };
 
     // Prefetch metadata with a single connection
     const metadata = await this.connector.withConnection(async (conn) => {
@@ -351,7 +354,6 @@ export class Profiler {
         scoredTables.reduce((s, t) => s + t.table_quality_score, 0) / scoredTables.length;
     }
 
-    return schemaProf;
   }
 
   private async fetchSchemaMetadata(

--- a/src/profiler/profiler.ts
+++ b/src/profiler/profiler.ts
@@ -277,8 +277,8 @@ export class Profiler {
         const prevKey = `${schema}.${tableName}`;
 
         // Checkpoint resume: skip already completed tables
+        // pbar.increment() yapma — startValue'da zaten sayildi
         if (completedTables.has(prevKey)) {
-          pbar.increment();
           return null;
         }
 

--- a/src/profiler/profiler.ts
+++ b/src/profiler/profiler.ts
@@ -26,6 +26,7 @@ import type {
   createDefaultColumnProfile,
 } from './types.js';
 import { createDefaultColumnProfile as makeColProfile, formatSize } from './types.js';
+import { CheckpointManager } from './checkpoint-manager.js';
 
 export class Profiler {
   private connector: BaseConnector;
@@ -37,6 +38,9 @@ export class Profiler {
   private quality: QualityScorer;
   private profConfig: AppConfig['profiling'];
   private dbConfig: DatabaseConfig;
+  private checkpointManager: CheckpointManager;
+  private checkpointInterval: number;
+  private outputDir: string;
 
   constructor(config: AppConfig, dbKey: string, connector: BaseConnector, sqlDir: string) {
     this.dbConfig = config.databases[dbKey];
@@ -53,6 +57,9 @@ export class Profiler {
     this.outlier = new OutlierDetector(this.sql, this.connector);
     this.quality = new QualityScorer(config.profiling.qualityWeights);
     this.profConfig = config.profiling;
+    this.checkpointInterval = config.profiling.checkpointInterval;
+    this.outputDir = config.outputDir;
+    this.checkpointManager = new CheckpointManager(config.outputDir);
   }
 
   async profileDatabase(
@@ -84,6 +91,22 @@ export class Profiler {
         }
       }
       logger.info(`[${this.dbConfig.alias}] Incremental mod: ${prevTableMap.size} onceki tablo yuklendi.`);
+    }
+
+    // Checkpoint resume
+    const completedTables = new Set<string>();
+    const checkpointData = this.checkpointManager.load(this.dbConfig.alias);
+    if (checkpointData) {
+      for (const t of checkpointData.completed_tables) {
+        completedTables.add(t);
+      }
+      // Restore partial profile schemas
+      for (const schema of checkpointData.partial_profile.schemas) {
+        dbProfile.schemas.push(schema);
+      }
+      logger.info(
+        `[${this.dbConfig.alias}] Checkpoint'ten devam ediliyor: ${completedTables.size} tablo atlanacak`,
+      );
     }
 
     if (!(await this.connector.testConnection())) {
@@ -122,12 +145,19 @@ export class Profiler {
       { format: `[${this.dbConfig.alias}] Profilleme |{bar}| {percentage}% | {value}/{total} | {postfix}` },
       Presets.shades_classic,
     );
-    pbar.start(totalTables, 0, { postfix: '' });
+    pbar.start(totalTables, completedTables.size, { postfix: '' });
 
     for (const schema of schemas) {
       const tables = schemaTables.get(schema) ?? [];
-      const schemaProf = await this.profileSchema(schema, tables, pbar, prevTableMap);
+
+      // Remove previously checkpointed version of this schema (resume case)
+      dbProfile.schemas = dbProfile.schemas.filter((s) => s.schema_name !== schema);
+
+      const schemaProf = await this.profileSchema(schema, tables, pbar, completedTables, prevTableMap);
       dbProfile.schemas.push(schemaProf);
+
+      // Checkpoint: save after each schema
+      this.checkpointManager.save(dbProfile, completedTables);
     }
 
     pbar.stop();
@@ -172,6 +202,9 @@ export class Profiler {
       );
     }
 
+    // Clear checkpoint after successful completion
+    this.checkpointManager.clear(this.dbConfig.alias);
+
     return dbProfile;
   }
 
@@ -179,6 +212,7 @@ export class Profiler {
     schema: string,
     tables: TableInfo[],
     pbar: SingleBar,
+    completedTables: Set<string>,
     prevTableMap?: Map<string, TableProfile>,
   ): Promise<SchemaProfile> {
     const logger = getLogger();
@@ -213,6 +247,12 @@ export class Profiler {
         const tableType = tableInfo.table_type;
         const estimated = tableInfo.estimated_rows;
         const prevKey = `${schema}.${tableName}`;
+
+        // Checkpoint resume: skip already completed tables
+        if (completedTables.has(prevKey)) {
+          pbar.increment();
+          return null;
+        }
 
         activeTables.add(tableName);
         updatePostfix();
@@ -265,6 +305,7 @@ export class Profiler {
         schemaProf.tables.push(tableProf);
         schemaProf.total_rows += tableProf.row_count;
         schemaProf.total_size_bytes += tableProf.table_size_bytes ?? 0;
+        completedTables.add(`${schema}.${tableProf.table_name}`);
       }
     }
 

--- a/src/profiler/profiler.ts
+++ b/src/profiler/profiler.ts
@@ -148,16 +148,22 @@ export class Profiler {
     pbar.start(totalTables, completedTables.size, { postfix: '' });
 
     // Graceful shutdown: Ctrl+C checkpoint kaydedip ciksin
+    // Windows raw-mode stdin'de SIGINT yerine \x03 byte gelir
     let interrupted = false;
-    const onSigint = () => {
+    const doShutdown = () => {
+      if (interrupted) return;
       interrupted = true;
       pbar.stop();
-      logger.info(`[${this.dbConfig.alias}] SIGINT alindi, checkpoint kaydediliyor...`);
+      logger.info(`[${this.dbConfig.alias}] Durduruldu, checkpoint kaydediliyor...`);
       this.checkpointManager.save(dbProfile, completedTables);
       logger.info(`[${this.dbConfig.alias}] Checkpoint kaydedildi (${completedTables.size}/${totalTables} tablo). Devam etmek icin tekrar calistirin.`);
       process.exit(0);
     };
-    process.on('SIGINT', onSigint);
+    process.on('SIGINT', doShutdown);
+    const onData = (data: Buffer) => {
+      if (data[0] === 0x03) doShutdown(); // Ctrl+C in raw mode
+    };
+    process.stdin.on('data', onData);
 
     for (const schema of schemas) {
       const tables = schemaTables.get(schema) ?? [];
@@ -172,7 +178,8 @@ export class Profiler {
       this.checkpointManager.save(dbProfile, completedTables);
     }
 
-    process.removeListener('SIGINT', onSigint);
+    process.removeListener('SIGINT', doShutdown);
+    process.stdin.removeListener('data', onData);
     pbar.stop();
 
     // Aggregation

--- a/src/profiler/profiler.ts
+++ b/src/profiler/profiler.ts
@@ -165,7 +165,7 @@ export class Profiler {
       // Remove previously checkpointed version of this schema (resume case)
       dbProfile.schemas = dbProfile.schemas.filter((s) => s.schema_name !== schema);
 
-      const schemaProf = await this.profileSchema(schema, tables, pbar, completedTables, prevTableMap);
+      const schemaProf = await this.profileSchema(schema, tables, pbar, completedTables, dbProfile, prevTableMap);
       dbProfile.schemas.push(schemaProf);
 
       // Checkpoint: save after each schema
@@ -226,6 +226,7 @@ export class Profiler {
     tables: TableInfo[],
     pbar: SingleBar,
     completedTables: Set<string>,
+    dbProfile: DatabaseProfile,
     prevTableMap?: Map<string, TableProfile>,
   ): Promise<SchemaProfile> {
     const logger = getLogger();
@@ -253,6 +254,10 @@ export class Profiler {
       const names = [...activeTables];
       pbar.update({ postfix: names.length > 0 ? names.join(', ') : '' });
     };
+
+    // Process tables in batches for checkpoint support
+    const interval = this.checkpointInterval;
+    let tablesSinceCheckpoint = 0;
 
     const tasks = tables.map((tableInfo) =>
       limit(async () => {
@@ -319,6 +324,13 @@ export class Profiler {
         schemaProf.total_rows += tableProf.row_count;
         schemaProf.total_size_bytes += tableProf.table_size_bytes ?? 0;
         completedTables.add(`${schema}.${tableProf.table_name}`);
+        tablesSinceCheckpoint++;
+
+        // Checkpoint every N tables within a schema
+        if (tablesSinceCheckpoint >= interval) {
+          this.checkpointManager.save(dbProfile, completedTables);
+          tablesSinceCheckpoint = 0;
+        }
       }
     }
 

--- a/src/profiler/profiler.ts
+++ b/src/profiler/profiler.ts
@@ -283,6 +283,8 @@ export class Profiler {
         updatePostfix();
 
         try {
+          let result: TableProfile | null = null;
+
           // Incremental: check if table changed since baseline
           if (prevTableMap?.has(prevKey)) {
             const prev = prevTableMap.get(prevKey)!;
@@ -292,26 +294,39 @@ export class Profiler {
             const colMeta = metadata.get(tableName) ?? [];
 
             if (rc.row_count === prev.row_count && colMeta.length === prev.column_count) {
-              const carried: TableProfile = {
+              result = {
                 ...prev,
                 estimated_rows: estimated,
                 incremental_status: 'unchanged',
               };
               logger.info(`[${prevKey}] Degisiklik yok, onceki profil tasindi.`);
-              return carried;
             }
           }
 
-          const tableProf = await this.connector.withConnection(async (conn) => {
-            return this.profileTable(conn, schema, tableName, tableType, estimated, metadata);
-          });
+          if (!result) {
+            result = await this.connector.withConnection(async (conn) => {
+              return this.profileTable(conn, schema, tableName, tableType, estimated, metadata);
+            });
 
-          // Mark incremental status
-          if (prevTableMap) {
-            tableProf.incremental_status = prevTableMap.has(prevKey) ? 'changed' : 'new';
+            // Mark incremental status
+            if (prevTableMap) {
+              result.incremental_status = prevTableMap.has(prevKey) ? 'changed' : 'new';
+            }
           }
 
-          return tableProf;
+          // Immediately track completed table for checkpoint
+          schemaProf.tables.push(result);
+          schemaProf.total_rows += result.row_count;
+          schemaProf.total_size_bytes += result.table_size_bytes ?? 0;
+          completedTables.add(prevKey);
+          tablesSinceCheckpoint++;
+
+          if (tablesSinceCheckpoint >= interval) {
+            this.checkpointManager.save(dbProfile, completedTables);
+            tablesSinceCheckpoint = 0;
+          }
+
+          return result;
         } catch (e) {
           logger.error(`[${schema}.${tableName}] Tablo profilleme hatasi: ${e}`);
           return null;
@@ -323,23 +338,7 @@ export class Profiler {
       }),
     );
 
-    const results = await Promise.all(tasks);
-
-    for (const tableProf of results) {
-      if (tableProf) {
-        schemaProf.tables.push(tableProf);
-        schemaProf.total_rows += tableProf.row_count;
-        schemaProf.total_size_bytes += tableProf.table_size_bytes ?? 0;
-        completedTables.add(`${schema}.${tableProf.table_name}`);
-        tablesSinceCheckpoint++;
-
-        // Checkpoint every N tables within a schema
-        if (tablesSinceCheckpoint >= interval) {
-          this.checkpointManager.save(dbProfile, completedTables);
-          tablesSinceCheckpoint = 0;
-        }
-      }
-    }
+    await Promise.all(tasks);
 
     schemaProf.total_size_display = formatSize(schemaProf.total_size_bytes);
 

--- a/src/profiler/profiler.ts
+++ b/src/profiler/profiler.ts
@@ -308,7 +308,7 @@ export class Profiler {
 
           if (!result) {
             result = await this.connector.withConnection(async (conn) => {
-              return this.profileTable(conn, schema, tableName, tableType, estimated, metadata);
+              return this.profileTable(conn, schema, tableName, tableType, estimated, metadata, tableInfo.table_description);
             });
 
             // Mark incremental status
@@ -411,6 +411,7 @@ export class Profiler {
     tableType: string,
     estimatedRows: number,
     metadata: Map<string, Record<string, unknown>[]>,
+    tableDescription?: string | null,
   ): Promise<TableProfile> {
     const startTime = Date.now();
 
@@ -426,7 +427,8 @@ export class Profiler {
 
     // Column metadata
     const colMeta = metadata.get(table) ?? [];
-    const tableDesc = colMeta[0]?.table_description != null ? String(colMeta[0].table_description) : null;
+    const tableDesc = tableDescription
+      ?? (colMeta[0]?.table_description != null ? String(colMeta[0].table_description) : null);
     if (colMeta.length === 0) {
       return {
         schema_name: schema,

--- a/src/profiler/profiler.ts
+++ b/src/profiler/profiler.ts
@@ -426,11 +426,13 @@ export class Profiler {
 
     // Column metadata
     const colMeta = metadata.get(table) ?? [];
+    const tableDesc = colMeta[0]?.table_description != null ? String(colMeta[0].table_description) : null;
     if (colMeta.length === 0) {
       return {
         schema_name: schema,
         table_name: table,
         table_type: tableType,
+        description: null,
         row_count: rowCount,
         estimated_rows: estimatedRows,
         row_count_estimated: rowEstimated,
@@ -476,6 +478,7 @@ export class Profiler {
       schema_name: schema,
       table_name: table,
       table_type: tableType,
+      description: tableDesc,
       row_count: rowCount,
       estimated_rows: estimatedRows,
       row_count_estimated: rowEstimated,

--- a/src/profiler/types.ts
+++ b/src/profiler/types.ts
@@ -37,6 +37,7 @@ export interface ColumnProfile {
   referenced_schema: string | null;
   referenced_table: string | null;
   referenced_column: string | null;
+  description: string | null;
   // Basic
   null_count: number;
   null_ratio: number;
@@ -164,6 +165,7 @@ export function createDefaultColumnProfile(colMeta: Record<string, unknown>): Co
     referenced_schema: colMeta.referenced_schema != null ? String(colMeta.referenced_schema) : null,
     referenced_table: colMeta.referenced_table != null ? String(colMeta.referenced_table) : null,
     referenced_column: colMeta.referenced_column != null ? String(colMeta.referenced_column) : null,
+    description: colMeta.column_description != null ? String(colMeta.column_description) : null,
     null_count: 0,
     null_ratio: 0.0,
     distinct_count: 0,

--- a/src/profiler/types.ts
+++ b/src/profiler/types.ts
@@ -128,6 +128,15 @@ export interface DatabaseProfile {
   incremental?: IncrementalSummary;
 }
 
+/** Checkpoint data for crash recovery. */
+export interface CheckpointData {
+  db_alias: string;
+  started_at: string;
+  updated_at: string;
+  completed_tables: string[];
+  partial_profile: DatabaseProfile;
+}
+
 /** Format bytes to human-readable size string. */
 export function formatSize(bytes: number | null): string {
   if (bytes == null || bytes === 0) return '0 B';

--- a/src/profiler/types.ts
+++ b/src/profiler/types.ts
@@ -206,6 +206,7 @@ export interface TableInfo {
   table_name: string;
   table_type: string;
   estimated_rows: number;
+  table_description?: string;
 }
 
 export interface RowCountResult {

--- a/src/profiler/types.ts
+++ b/src/profiler/types.ts
@@ -77,6 +77,7 @@ export interface TableProfile {
   schema_name: string;
   table_name: string;
   table_type: string;
+  description: string | null;
   row_count: number;
   estimated_rows: number;
   row_count_estimated: boolean;

--- a/src/report/excel-report.ts
+++ b/src/report/excel-report.ts
@@ -145,7 +145,7 @@ export class ExcelReportGenerator {
     const ws = wb.addWorksheet('Tablo Profil');
     const hasIncremental = profile.incremental?.enabled;
     const headers = [
-      'Sema', 'Tablo', 'Tip', 'Satir Sayisi', 'Tahmini', 'Boyut',
+      'Sema', 'Tablo', 'Aciklama', 'Tip', 'Satir Sayisi', 'Tahmini', 'Boyut',
       'Kolon Sayisi', 'Sampling', 'Sample %',
       'Kalite Skoru', 'Kalite Notu', 'Sure (sn)',
       ...(hasIncremental ? ['Durum'] : []),
@@ -166,24 +166,25 @@ export class ExcelReportGenerator {
     let r = 2;
     for (const schema of profile.schemas) {
       for (const table of schema.tables) {
-        const colCount = hasIncremental ? 13 : 12;
+        const colCount = hasIncremental ? 14 : 13;
         ws.getRow(r).getCell(1).value = table.schema_name;
         ws.getRow(r).getCell(2).value = table.table_name;
-        ws.getRow(r).getCell(3).value = table.table_type;
-        ws.getRow(r).getCell(4).value = table.row_count;
-        ws.getRow(r).getCell(5).value = table.row_count_estimated ? 'Evet' : 'Hayir';
-        ws.getRow(r).getCell(6).value = table.table_size_display || '-';
-        ws.getRow(r).getCell(7).value = table.column_count;
-        ws.getRow(r).getCell(8).value = table.sampled ? 'Evet' : 'Hayir';
-        ws.getRow(r).getCell(9).value = table.sample_percent ?? '';
-        ws.getRow(r).getCell(10).value = Math.round(table.table_quality_score * 10000) / 10000;
-        const gradeCell = ws.getRow(r).getCell(11);
+        ws.getRow(r).getCell(3).value = table.description ?? '';
+        ws.getRow(r).getCell(4).value = table.table_type;
+        ws.getRow(r).getCell(5).value = table.row_count;
+        ws.getRow(r).getCell(6).value = table.row_count_estimated ? 'Evet' : 'Hayir';
+        ws.getRow(r).getCell(7).value = table.table_size_display || '-';
+        ws.getRow(r).getCell(8).value = table.column_count;
+        ws.getRow(r).getCell(9).value = table.sampled ? 'Evet' : 'Hayir';
+        ws.getRow(r).getCell(10).value = table.sample_percent ?? '';
+        ws.getRow(r).getCell(11).value = Math.round(table.table_quality_score * 10000) / 10000;
+        const gradeCell = ws.getRow(r).getCell(12);
         gradeCell.value = table.table_quality_grade;
         gradeCell.fill = GRADE_FILLS[table.table_quality_grade] ?? GRADE_FILLS['F'];
-        ws.getRow(r).getCell(12).value = table.profile_duration_sec;
+        ws.getRow(r).getCell(13).value = table.profile_duration_sec;
 
         if (hasIncremental && table.incremental_status) {
-          const statusCell = ws.getRow(r).getCell(13);
+          const statusCell = ws.getRow(r).getCell(14);
           statusCell.value = STATUS_LABELS[table.incremental_status] ?? table.incremental_status;
 
           // Color unchanged rows with dim background

--- a/src/report/excel-report.ts
+++ b/src/report/excel-report.ts
@@ -206,7 +206,7 @@ export class ExcelReportGenerator {
   private writeColumnProfile(wb: ExcelJS.Workbook, profile: DatabaseProfile): void {
     const ws = wb.addWorksheet('Kolon Profil');
     const headers = [
-      'Sema', 'Tablo', 'Kolon', 'Sira', 'Veri Tipi', 'Max Uzunluk',
+      'Sema', 'Tablo', 'Kolon', 'Aciklama', 'Sira', 'Veri Tipi', 'Max Uzunluk',
       'Nullable', 'PK', 'FK',
       'NULL Sayisi', 'NULL Orani', 'Distinct Sayisi', 'Distinct Orani',
       'Min', 'Max',
@@ -222,36 +222,37 @@ export class ExcelReportGenerator {
           ws.getRow(r).getCell(1).value = table.schema_name;
           ws.getRow(r).getCell(2).value = table.table_name;
           ws.getRow(r).getCell(3).value = col.column_name;
-          ws.getRow(r).getCell(4).value = col.ordinal_position;
-          ws.getRow(r).getCell(5).value = col.data_type;
-          ws.getRow(r).getCell(6).value = col.max_length ?? '';
-          ws.getRow(r).getCell(7).value = col.is_nullable;
-          ws.getRow(r).getCell(8).value = col.is_primary_key ? 'PK' : '';
-          ws.getRow(r).getCell(9).value = col.is_foreign_key ? 'FK' : '';
-          ws.getRow(r).getCell(10).value = col.null_count;
-          ws.getRow(r).getCell(11).value = col.null_ratio;
-          ws.getRow(r).getCell(12).value = col.distinct_count;
-          ws.getRow(r).getCell(13).value = col.distinct_ratio;
-          ws.getRow(r).getCell(14).value = col.min_value ?? '';
-          ws.getRow(r).getCell(15).value = col.max_value ?? '';
-          ws.getRow(r).getCell(16).value = col.mean ?? '';
-          ws.getRow(r).getCell(17).value = col.stddev ?? '';
-          ws.getRow(r).getCell(18).value = col.percentiles?.p25 ?? '';
-          ws.getRow(r).getCell(19).value = col.percentiles?.p50 ?? '';
-          ws.getRow(r).getCell(20).value = col.percentiles?.p75 ?? '';
-          ws.getRow(r).getCell(21).value = Math.round(col.quality_score * 10000) / 10000;
-          const gradeCell = ws.getRow(r).getCell(22);
+          ws.getRow(r).getCell(4).value = col.description ?? '';
+          ws.getRow(r).getCell(5).value = col.ordinal_position;
+          ws.getRow(r).getCell(6).value = col.data_type;
+          ws.getRow(r).getCell(7).value = col.max_length ?? '';
+          ws.getRow(r).getCell(8).value = col.is_nullable;
+          ws.getRow(r).getCell(9).value = col.is_primary_key ? 'PK' : '';
+          ws.getRow(r).getCell(10).value = col.is_foreign_key ? 'FK' : '';
+          ws.getRow(r).getCell(11).value = col.null_count;
+          ws.getRow(r).getCell(12).value = col.null_ratio;
+          ws.getRow(r).getCell(13).value = col.distinct_count;
+          ws.getRow(r).getCell(14).value = col.distinct_ratio;
+          ws.getRow(r).getCell(15).value = col.min_value ?? '';
+          ws.getRow(r).getCell(16).value = col.max_value ?? '';
+          ws.getRow(r).getCell(17).value = col.mean ?? '';
+          ws.getRow(r).getCell(18).value = col.stddev ?? '';
+          ws.getRow(r).getCell(19).value = col.percentiles?.p25 ?? '';
+          ws.getRow(r).getCell(20).value = col.percentiles?.p50 ?? '';
+          ws.getRow(r).getCell(21).value = col.percentiles?.p75 ?? '';
+          ws.getRow(r).getCell(22).value = Math.round(col.quality_score * 10000) / 10000;
+          const gradeCell = ws.getRow(r).getCell(23);
           gradeCell.value = col.quality_grade;
           gradeCell.fill = GRADE_FILLS[col.quality_grade] ?? GRADE_FILLS['F'];
-          ws.getRow(r).getCell(23).value = col.quality_flags.join(', ');
+          ws.getRow(r).getCell(24).value = col.quality_flags.join(', ');
 
           // PK/FK row highlighting
           if (col.is_primary_key) {
-            for (let c = 1; c <= 23; c++) ws.getRow(r).getCell(c).fill = PK_FILL;
+            for (let c = 1; c <= 24; c++) ws.getRow(r).getCell(c).fill = PK_FILL;
           } else if (col.is_foreign_key) {
-            for (let c = 1; c <= 23; c++) ws.getRow(r).getCell(c).fill = FK_FILL;
+            for (let c = 1; c <= 24; c++) ws.getRow(r).getCell(c).fill = FK_FILL;
           }
-          for (let c = 1; c <= 23; c++) ws.getRow(r).getCell(c).border = THIN_BORDER;
+          for (let c = 1; c <= 24; c++) ws.getRow(r).getCell(c).border = THIN_BORDER;
           r++;
         }
       }

--- a/src/ui/menus.ts
+++ b/src/ui/menus.ts
@@ -23,6 +23,7 @@ import { checkGraphviz } from '../er-diagram/graphviz.js';
 import { SensitivityAnalyzer } from '../metrics/sensitivity.js';
 import type { SensitivityLevel } from '../metrics/sensitivity.js';
 import { ExcelReportGenerator } from '../report/excel-report.js';
+import { CheckpointManager } from '../profiler/checkpoint-manager.js';
 
 /* ------------------------------------------------------------------ */
 /*  Top-level entry                                                    */
@@ -441,6 +442,33 @@ async function profileFlow(config: AppConfig, pkgRoot: string): Promise<void> {
 
     p.log.step(`${C.bold(key)} profilleme basliyor...`);
     logger.info(`=== Profilleme basliyor: ${key} ===`);
+
+    // Checkpoint resume check
+    const ckptMgr = new CheckpointManager(config.outputDir);
+
+    if (ckptMgr.exists(key)) {
+      const info = ckptMgr.getInfo(key);
+      if (info) {
+        await resetStdin();
+        const resumeChoice = await p.select({
+          message: `${C.bold(key)} icin tamamlanmamis profilleme bulundu (${info.completedCount} tablo, ${new Date(info.updatedAt).toLocaleString('tr-TR')})`,
+          options: [
+            { value: 'resume' as const, label: 'Kaldigi yerden devam et' },
+            { value: 'restart' as const, label: 'Sifirdan basla (checkpoint silinir)' },
+          ],
+        });
+
+        if (p.isCancel(resumeChoice)) {
+          await destroyConnectors(connectors);
+          return;
+        }
+
+        if (resumeChoice === 'restart') {
+          ckptMgr.clear(key);
+        }
+        // 'resume' case: Profiler.profileDatabase() will load checkpoint automatically
+      }
+    }
 
     const profiler = new Profiler(config, key, connector, sqlDir);
     const tableMap = selectedTables.get(key);

--- a/templates/partials/schema_summary.html.j2
+++ b/templates/partials/schema_summary.html.j2
@@ -14,6 +14,7 @@
       <thead>
         <tr>
           <th>Tablo</th>
+          <th>Aciklama</th>
           <th>Satir</th>
           <th>Boyut</th>
           <th>Kolon</th>
@@ -31,6 +32,7 @@
               {{ table.table_name }}
             </a>
           </td>
+          <td style="font-size:11px; color:var(--text-muted);">{{ table.description or '' }}</td>
           <td>{{ table.row_count | numfmt }}{% if table.row_count_estimated %} *{% endif %}</td>
           <td>{{ table.table_size_display or '-' }}</td>
           <td>{{ table.column_count }}</td>

--- a/templates/partials/table_detail.html.j2
+++ b/templates/partials/table_detail.html.j2
@@ -16,6 +16,7 @@
         <tr>
           <th>#</th>
           <th>Kolon</th>
+          <th>Aciklama</th>
           <th>Tip</th>
           <th>NULL</th>
           <th>NULL %</th>
@@ -38,6 +39,7 @@
             <span class="badge" style="background: {% if col.sensitivity.level == 'high' %}#f4cccc{% elif col.sensitivity.level == 'medium' %}#fce4d6{% else %}#fff2cc{% endif %}; padding: 2px 6px; border-radius: 3px; font-size: 0.75em;">{{ col.sensitivity | sensitivity_label }}</span>
             {% endif %}
           </td>
+          <td style="font-size:11px; color:var(--text-muted);">{{ col.description or '' }}</td>
           <td>{{ col.data_type }}{% if col.max_length %}({{ col.max_length }}){% endif %}</td>
           <td>
             <span class="null-bar">


### PR DESCRIPTION
## Summary
- Profilleme sirasinda her schema bitisinde otomatik checkpoint kaydeder (`output/.tmp/checkpoint_{db}.json`)
- Crash/timeout sonrasi yeniden baslatildiginda kaldiigi yerden devam eder
- UI'da resume/restart secenegi sunar
- Closes #26

## Degisiklikler
- `src/profiler/checkpoint-manager.ts` — Yeni CheckpointManager sinifi (save/load/clear/exists)
- `src/profiler/profiler.ts` — Checkpoint entegrasyonu (resume + save + clear)
- `src/ui/menus.ts` — Resume prompt'u
- `src/config/` — `checkpointInterval` config (default: 100)
- `src/profiler/types.ts` — `CheckpointData` type

## Test plan
- [x] 9/9 vitest pass (unit + integration)
- [x] tsc --noEmit clean
- [x] npm run build clean
- [x] Manuel test: profilleme baslatip Ctrl+C ile kes, yeniden baslat, resume secenegi geldigini dogrula

🤖 Generated with [Claude Code](https://claude.com/claude-code)